### PR TITLE
Arbitrum configs

### DIFF
--- a/Metrics/config/arbitrum.json
+++ b/Metrics/config/arbitrum.json
@@ -1,0 +1,9 @@
+{
+    "network" : "arbitrum-one",
+    "startBlock": 99504000,
+    "RubiconMarket-address" : "0xC715a30FDe987637A082Cf5F19C74648b67f2db8", 
+    "RubiconRouter-address" : "0x7B24e6F4Dd84674696c2a5809c24154EC6AC7F03",
+    "MarketAidFactory-address" : "0x6CB24A263732579EfD56f3E071851e989d78cE75",
+    "BathHouse-address" : "0x1229036F63679B61910CB1463e5BB57f68D19bb2",
+    "BathPair-address" : "0x9dBf17d518f722B5Aae5573D808B94024b635529" 
+} 

--- a/Metrics/package.json
+++ b/Metrics/package.json
@@ -5,10 +5,12 @@
     "scripts": {
         "prepare:optimism": "mustache config/optimism_mainnet.json subgraph.template.yaml > subgraph.yaml",
         "prepare:optimism:goerli": "mustache config/optimism_goerli.json subgraph.template.yaml > subgraph.yaml",
+        "prepare:arbitrum": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml",
         "codegen": "graph codegen",
         "build": "graph build",
         "deploy:optimism": "graph deploy --product hosted-service denverbaumgartner/rubiconmetricsoptimism",
         "deploy:optimism:goerli": "graph deploy --product hosted-service <username>/<subgraph>",
+        "deploy:arbitrum": "graph deploy --product hosted-service jossduff/rubiconmetricsarbitrum",
         "create-local": "graph create --node http://localhost:8020/ Metrics",
         "remove-local": "graph remove --node http://localhost:8020/ Metrics",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 Metrics"


### PR DESCRIPTION
Added `config/arbitrum.json` and `package.json` commands to deploy this metrics subgraph to arbitrum.

Pushing in case we need to redeploy at some point.

Note:
We have to supply a `BathHouse-address` and `BathPair-address` to the config file, but these contracts were depreciated with V2.  Rather than refactoring more of `Metrics`, I just put in dummy addresses.  Synced fine.